### PR TITLE
商品一覧表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,7 @@
 class ItemsController < ApplicationController
   before_action :item_validates, except: [:index]
   def index
-     @item = Item.all.order("created_at DESC")
-  
+    @item = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,8 +1,8 @@
 class ItemsController < ApplicationController
   before_action :item_validates, except: [:index]
   def index
-    # @item = Item.all
-    # 商品一覧機能実装時に使用
+     @item = Item.all.order("created_at DESC")
+  
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
     <ul class='item-lists'>
      
       <% @item.each do |item| %>
-        <%# if @item[0] != nil %>
+        <% if @item[0] != nil %>
         <li class='list'>
         <%= link_to "#" do %>
           <div class='item-img-content'>
@@ -157,11 +157,11 @@
           </div>
         <% end %>
         </li>
-      <%# end %>
+      <% end %>
       <% end %>
 
       
-      <%# if @item.length == 0 %>
+      <% if @item.length == 0 %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -179,7 +179,7 @@
         </div>
         
       </li>
-      <%# end %>
+      <% end %>
       <% end %>
       
     </ul>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -136,11 +136,11 @@
             
             <%= image_tag item.image, class: "item-img" if item.image.attached? %>
             
-            <%# 商品が売れていればsold outを表示しましょう %>
+            
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
+            
 
             </div>
             <div class='item-info'>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,15 +128,14 @@
     </div>
     <ul class='item-lists'>
      
-      <%# @item.each do |item| %>
+      <% @item.each do |item| %>
         <%# if @item[0] != nil %>
         <li class='list'>
         <%= link_to "#" do %>
           <div class='item-img-content'>
             
-            <%#= image_tag item.image, class: "item-img" if item.image.attached? %>
-            <%= image_tag "item-sample.png", class: "item-img" %>
-
+            <%= image_tag item.image, class: "item-img" if item.image.attached? %>
+            
             <%# 商品が売れていればsold outを表示しましょう %>
             <div class='sold-out'>
               <span>Sold Out!!</span>
@@ -146,10 +145,10 @@
             </div>
             <div class='item-info'>
             <h3 class='item-name'>
-              <%#= item.products %>
+              <%= item.products %>
             </h3>
             <div class='item-price'>
-              <span><%#= item.price %>円<br><%#= item.delivery_charge.name %></span>
+              <span><%= item.price %>円<br><%= item.delivery_charge.name %></span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -159,7 +158,7 @@
         <% end %>
         </li>
       <%# end %>
-      <%# end %>
+      <% end %>
 
       
       <%# if @item.length == 0 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,8 +128,9 @@
     </div>
     <ul class='item-lists'>
      
+     <% if @item[0] != nil %>
       <% @item.each do |item| %>
-        <% if @item[0] != nil %>
+        
         <li class='list'>
         <%= link_to "#" do %>
           <div class='item-img-content'>
@@ -137,9 +138,11 @@
             <%= image_tag item.image, class: "item-img" if item.image.attached? %>
             
             
+            <%# 商品が売れていればsold outを表示しましょう %>
             <div class='sold-out'>
               <span>Sold Out!!</span>
             </div>
+            <%# // 商品が売れていればsold outを表示しましょう %>
             
 
             </div>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -81,9 +81,8 @@ RSpec.describe Item, type: :model do
       it 'userが紐づいていなければ保存できない' do
         @item.user = nil
         @item.valid?
-        expect(@item.errors.full_messages).to include("User must exist")
+        expect(@item.errors.full_messages).to include('User must exist')
       end
-
     end
   end
 end


### PR DESCRIPTION
# what
商品一覧表示機能の実装
# why
トップページで商品一覧を見れるようにするため。

商品のデータがない場合は、ダミー商品が表示されている動画
https://gyazo.com/ca811d60175167254129cf1c4ef68380
商品のデータがある場合は、商品が一覧で表示されている動画
https://gyazo.com/a3f4e5749293f52eaf2a35d4fdd07714